### PR TITLE
Fix undefined symbol errors with Ruby 2.7+

### DIFF
--- a/ext/bitset/bitset.c
+++ b/ext/bitset/bitset.c
@@ -556,10 +556,10 @@ static VALUE rb_bitset_equal(VALUE self, VALUE other) {
 }
 
 typedef uint64_t (*bitwise_op)(uint64_t, uint64_t);
-inline uint64_t bitset_and(uint64_t a, uint64_t b) { return a & b; }
-inline uint64_t bitset_or(uint64_t a, uint64_t b) { return a | b; }
-inline uint64_t bitset_xor(uint64_t a, uint64_t b) { return a ^ b; }
-inline uint64_t bitset_difference(uint64_t a, uint64_t b) { return a & ~b; }
+static uint64_t bitset_and(uint64_t a, uint64_t b) { return a & b; }
+static uint64_t bitset_or(uint64_t a, uint64_t b) { return a | b; }
+static uint64_t bitset_xor(uint64_t a, uint64_t b) { return a ^ b; }
+static uint64_t bitset_difference(uint64_t a, uint64_t b) { return a & ~b; }
 
 static VALUE mutable(VALUE self, VALUE other, bitwise_op operator) {
     Bitset * bs = get_bitset(self);

--- a/ext/bitset/bitset.c
+++ b/ext/bitset/bitset.c
@@ -556,10 +556,10 @@ static VALUE rb_bitset_equal(VALUE self, VALUE other) {
 }
 
 typedef uint64_t (*bitwise_op)(uint64_t, uint64_t);
-inline uint64_t and(uint64_t a, uint64_t b) { return a & b; }
-inline uint64_t or(uint64_t a, uint64_t b) { return a | b; }
-inline uint64_t xor(uint64_t a, uint64_t b) { return a ^ b; }
-inline uint64_t difference(uint64_t a, uint64_t b) { return a & ~b; }
+inline uint64_t bitset_and(uint64_t a, uint64_t b) { return a & b; }
+inline uint64_t bitset_or(uint64_t a, uint64_t b) { return a | b; }
+inline uint64_t bitset_xor(uint64_t a, uint64_t b) { return a ^ b; }
+inline uint64_t bitset_difference(uint64_t a, uint64_t b) { return a & ~b; }
 
 static VALUE mutable(VALUE self, VALUE other, bitwise_op operator) {
     Bitset * bs = get_bitset(self);
@@ -578,19 +578,19 @@ static VALUE mutable(VALUE self, VALUE other, bitwise_op operator) {
 }
 
 static VALUE rb_bitset_union_mutable(VALUE self, VALUE other) {
-    return mutable(self, other, &or);
+    return mutable(self, other, &bitset_or);
 }
 
 static VALUE rb_bitset_intersect_mutable(VALUE self, VALUE other) {
-    return mutable(self, other, &and);
+    return mutable(self, other, &bitset_and);
 }
 
 static VALUE rb_bitset_xor_mutable(VALUE self, VALUE other) {
-    return mutable(self, other, &xor);
+    return mutable(self, other, &bitset_xor);
 }
 
 static VALUE rb_bitset_difference_mutable(VALUE self, VALUE other) {
-    return mutable(self, other, &difference);
+    return mutable(self, other, &bitset_difference);
 }
 
 static VALUE rb_bitset_reset(VALUE self) {


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — tagged directly as v1.2.2

This branch has been tagged as `v1.2.2` and is already in use via `tag: "v1.2.2"` in the bookingbug app Gemfile. **Do not merge to master** — it is not needed and could affect other environments that depend on the default branch.

This PR remains open for documentation/review purposes only.

---

## Summary

- Rename C functions `and`, `or`, `xor`, `difference` to `bitset_and`, `bitset_or`, `bitset_xor`, `bitset_difference`
- Change `inline` to `static` (C99 `inline` doesn't guarantee symbol emission; taking function pointers fails at link time)
- Rename pointer references (`&and` → `&bitset_and`, etc.)
- Ruby method aliases (`"and"`, `"or"`, `"xor"`) are **unchanged** — no API change

## Why

`and` and `or` are [ISO C95 alternative operator tokens](https://en.cppreference.com/w/c/language/operator_alternative) defined in `<iso646.h>` as `#define and &&` / `#define or ||`. Ruby 2.7+ headers include this header, so the preprocessor replaces the function names with operators during compilation. The `.so` compiles but the symbols are mangled/missing, resulting in:

```
LoadError: .../bitset.so: undefined symbol: and
```

Additionally, C99 `inline` without `static` or `extern` does not guarantee the compiler emits a standalone symbol. When function pointers are taken (`&bitset_or`), the linker fails with `undefined symbol: bitset_or`. Using `static` ensures symbols are always emitted.

## Tagged as v1.2.2

```
git tag v1.2.2  →  b95d1c420d799d5f8902ca8031bde73058e54683
```

Usage in bookingbug Gemfile:
```ruby
gem "bitset", git: "https://github.com/BookingBug/bitset.git", tag: "v1.2.2"
```

## Test plan

- [x] Verified diff only touches internal C function names (4 definitions + 4 pointer refs)
- [x] Tagged as v1.2.2, Gemfile updated in DEV-6939
- [ ] Deploy to DEV05 under Ruby 2.7.8 — confirm `db:migrate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)